### PR TITLE
Add drjit-cpp CTest runtime smoke

### DIFF
--- a/recipe/run_test_cpp.bat
+++ b/recipe/run_test_cpp.bat
@@ -16,3 +16,7 @@ if errorlevel 1 exit 1
 
 cmake --build tests/build --parallel --config Release
 if errorlevel 1 exit 1
+
+set PATH=%LIBRARY_BIN%;%PATH%
+ctest --test-dir tests/build --output-on-failure --build-config Release
+if errorlevel 1 exit 1

--- a/recipe/run_test_cpp.sh
+++ b/recipe/run_test_cpp.sh
@@ -28,3 +28,7 @@ cmake tests \
   -DENABLE_CUDA=$ENABLE_CUDA
 
 cmake --build tests/build --parallel
+
+export LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH:-}"
+export DYLD_FALLBACK_LIBRARY_PATH="${PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
+ctest --test-dir tests/build --output-on-failure

--- a/recipe/tests/CMakeLists.txt
+++ b/recipe/tests/CMakeLists.txt
@@ -7,9 +7,15 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-project(adaptivecpp-example)
+project(drjit-example LANGUAGES CXX)
+
+enable_testing()
 
 find_package(drjit CONFIG REQUIRED)
+
+add_executable(half_smoke half_smoke.cpp)
+target_link_libraries(half_smoke PRIVATE drjit)
+add_test(NAME half_smoke COMMAND half_smoke)
 
 add_executable(half half.cpp)
 target_link_libraries(half PRIVATE drjit)

--- a/recipe/tests/half_smoke.cpp
+++ b/recipe/tests/half_smoke.cpp
@@ -1,0 +1,19 @@
+#define DRJIT_INCLUDE_FLOAT16_FALLBACK 1
+
+#include <drjit-core/half.h>
+
+#include <cmath>
+#include <iostream>
+
+int main() {
+    const drjit::half one = drjit::half::from_binary(0x3c00);
+    const drjit::half three_halves(1.5f);
+
+    const float sum = static_cast<float>(one) + static_cast<float>(three_halves);
+    if (std::abs(sum - 2.5f) > 0.001f) {
+        std::cerr << "unexpected half conversion result: " << sum << std::endl;
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This keeps the existing downstream CMake consumer test, but also runs a tiny CTest executable from the installed package test environment.

The new smoke covers the installed `drjit` CMake package path plus a cheap `drjit-core` half conversion at runtime, without running the exhaustive half-precision loop or requiring a live CUDA device.

Validation before opening:
- `git diff --check`
- `conda-smithy recipe-lint --conda-forge recipe`

This is test-only, so there is no build number bump.