### PR TITLE
Enable Dr.Jit Metal on osx-arm64

### DIFF
--- a/.ci_support/osx_arm64_build_modecppllvm_version18.yaml
+++ b/.ci_support/osx_arm64_build_modecppllvm_version18.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '15.0'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '15.5'
 build_mode:
 - cpp
 c_compiler:
@@ -11,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '15.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_build_modecppllvm_version19.yaml
+++ b/.ci_support/osx_arm64_build_modecppllvm_version19.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '15.0'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '15.5'
 build_mode:
 - cpp
 c_compiler:
@@ -11,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '15.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_build_modecppllvm_version20.yaml
+++ b/.ci_support/osx_arm64_build_modecppllvm_version20.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '15.0'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '15.5'
 build_mode:
 - cpp
 c_compiler:
@@ -11,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '15.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_build_modecppllvm_version21.yaml
+++ b/.ci_support/osx_arm64_build_modecppllvm_version21.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '15.0'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '15.5'
 build_mode:
 - cpp
 c_compiler:
@@ -11,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '15.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_build_modepythonllvm_version18.yaml
+++ b/.ci_support/osx_arm64_build_modepythonllvm_version18.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '15.0'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '15.5'
 build_mode:
 - python
 c_compiler:
@@ -11,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '15.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_build_modepythonllvm_version19.yaml
+++ b/.ci_support/osx_arm64_build_modepythonllvm_version19.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '15.0'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '15.5'
 build_mode:
 - python
 c_compiler:
@@ -11,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '15.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_build_modepythonllvm_version20.yaml
+++ b/.ci_support/osx_arm64_build_modepythonllvm_version20.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '15.0'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '15.5'
 build_mode:
 - python
 c_compiler:
@@ -11,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '15.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_build_modepythonllvm_version21.yaml
+++ b/.ci_support/osx_arm64_build_modepythonllvm_version21.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '15.0'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '15.5'
 build_mode:
 - python
 c_compiler:
@@ -11,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '15.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/build_cpp.sh
+++ b/recipe/build_cpp.sh
@@ -5,8 +5,13 @@ set -exo pipefail
 if [[ "${target_platform}" == osx-* ]]; then
   # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
   CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
-  # Dr.Jit 1.4.0's Metal backend requires Metal APIs newer than conda-forge's macOS 11 SDK.
-  export CMAKE_ARGS="${CMAKE_ARGS:-} -DDRJIT_ENABLE_METAL=OFF"
+  # Dr.Jit 1.4.0's Metal backend needs macOS 15 APIs. Enable it only on osx-arm64,
+  # where the recipe raises the SDK and deployment target for Apple Silicon GPUs.
+  if [[ "${target_platform}" == "osx-arm64" ]]; then
+    export CMAKE_ARGS="${CMAKE_ARGS:-} -DDRJIT_ENABLE_METAL=ON"
+  else
+    export CMAKE_ARGS="${CMAKE_ARGS:-} -DDRJIT_ENABLE_METAL=OFF"
+  fi
 fi
 
 if [[ "${target_platform}" == *aarch64 || "${target_platform}" == *ppc64le ]]; then

--- a/recipe/build_py.sh
+++ b/recipe/build_py.sh
@@ -5,8 +5,13 @@ set -euxo pipefail
 if [[ "${target_platform}" == osx-* ]]; then
   # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
   CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
-  # Dr.Jit 1.4.0's Metal backend requires Metal APIs newer than conda-forge's macOS 11 SDK.
-  export CMAKE_ARGS="${CMAKE_ARGS:-} -DDRJIT_ENABLE_METAL=OFF"
+  # Dr.Jit 1.4.0's Metal backend needs macOS 15 APIs. Enable it only on osx-arm64,
+  # where the recipe raises the SDK and deployment target for Apple Silicon GPUs.
+  if [[ "${target_platform}" == "osx-arm64" ]]; then
+    export CMAKE_ARGS="${CMAKE_ARGS:-} -DDRJIT_ENABLE_METAL=ON"
+  else
+    export CMAKE_ARGS="${CMAKE_ARGS:-} -DDRJIT_ENABLE_METAL=OFF"
+  fi
 fi
 
 if [[ "${cuda_compiler_version:-None}" != "None" ]]; then

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -10,6 +10,13 @@ build_mode:
   - cpp
   - python
 
+# Dr.Jit's Metal backend uses Metal APIs introduced in macOS 15.0.
+MACOSX_SDK_VERSION:  # [osx and arm64]
+  - '15.5'           # [osx and arm64]
+
+c_stdlib_version:  # [osx and arm64]
+  - '15.0'         # [osx and arm64]
+
 c_stdlib_version:  # [linux]
   - '2.17'         # [linux]
   - '2.17'         # [linux]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 context:
   name: drjit-cpp
   version: "1.4.0"
-  build_number: 0
+  build_number: 1
 
 recipe:
   name: ${{ name|lower }}-split


### PR DESCRIPTION
## Motivation

Dr.Jit 1.4.0 enables its Metal backend by default on Apple platforms, and the upstream option describes this backend as intended for Apple Silicon GPUs. In #45, conda-forge had to keep Metal disabled because the default macOS 11 SDK does not provide the newer Metal APIs used by the 1.4.0 source.

This follow-up enables Metal only for `osx-arm64`, where the backend is relevant, while keeping `osx-64` on the existing macOS 11 baseline.

## Changes

- Bump the build number to 1.
- Set `osx-arm64` to macOS SDK 15.5 and deployment/runtime target 15.0 through `c_stdlib_version`.
- Pass `-DDRJIT_ENABLE_METAL=ON` only for `target_platform == osx-arm64`.
- Keep `-DDRJIT_ENABLE_METAL=OFF` for `osx-64` and non-macOS platforms.
- Rerender the affected `osx-arm64` CI configs.

## References

- Follow-up to #45.
- Upstream Metal option: https://github.com/mitsuba-renderer/drjit/blob/v1.4.0/CMakeLists.txt#L12-L26
- Dr.Jit 1.4.0's vendored `drjit-core` uses newer Metal APIs such as `MTLCompileOptions.mathMode` / `MTLLanguageVersion3_2`: https://github.com/mitsuba-renderer/drjit-core/blob/c9c054928c55da09c1756366d62e60c23ceceefd/src/metal_core.mm#L400-L413
- It also uses GPU address APIs such as `MTLBuffer.gpuAddress`: https://github.com/mitsuba-renderer/drjit-core/blob/c9c054928c55da09c1756366d62e60c23ceceefd/src/metal_launch.h#L29-L33
- conda-forge guidance for newer macOS SDKs: https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-macos-sdks
- SDK package source tags: https://github.com/alexey-lysiuk/macos-sdk/tags

## Validation

- `git diff --text --check HEAD~2..HEAD`
- `conda-smithy recipe-lint --conda-forge recipe`
- `conda-smithy rerender --check --feedstock_directory .`
- `pixi exec -s rattler-build rattler-build build -r recipe --render-only -m .ci_support/osx_arm64_build_modecppllvm_version18.yaml --target-platform osx-arm64 --log-style plain`
- `pixi exec -s rattler-build rattler-build build -r recipe --render-only -m .ci_support/osx_arm64_build_modepythonllvm_version18.yaml --target-platform osx-arm64 --variant 'python=3.12.* *_cpython' --log-style plain`
- `pixi exec -s rattler-build rattler-build build -r recipe --render-only -m .ci_support/osx_64_build_modecppllvm_version18.yaml --target-platform osx-64 --log-style plain`

The full Metal compile needs conda-forge macOS CI; my local validation host is Linux.
